### PR TITLE
Fix protein requirements to match endurance hiking guidelines

### DIFF
--- a/pages/food/ShowTotals.js
+++ b/pages/food/ShowTotals.js
@@ -158,8 +158,9 @@ class ShowTotals extends Renderer {
   }
 
   goalProtein() {
-    // 18% of calories from protein (4 calories per gram of protein)
-    return (this.goalCalories() * 0.18) / 4
+    // 12.5% of calories from protein (middle of 10-15% range for endurance activities)
+    // 4 calories per gram of protein
+    return (this.goalCalories() * 0.125) / 4
   }
 
   totalCalories() {


### PR DESCRIPTION
Updated protein goal from 18% to 12.5% of calories (middle of recommended 10-15% range). Research shows endurance hikers need 1-1.6g/kg body weight or 10-15% of total calories from protein, not 18%.

🤖 Generated with [Claude Code](https://claude.ai/code)